### PR TITLE
Update interval to be 60 across all sources.

### DIFF
--- a/ceilometer/files/kilo/pipeline.yaml
+++ b/ceilometer/files/kilo/pipeline.yaml
@@ -8,7 +8,7 @@
 ---
 sources:
     - name: meter_source
-      interval: 600
+      interval: 60
       meters:
           - "*"
       sinks:
@@ -20,7 +20,7 @@ sources:
       sinks:
           - cpu_sink
     - name: disk_source
-      interval: 600
+      interval: 60
       meters:
           - "disk.read.bytes"
           - "disk.read.requests"
@@ -33,7 +33,7 @@ sources:
       sinks:
           - disk_sink
     - name: network_source
-      interval: 600
+      interval: 60
       meters:
           - "network.incoming.bytes"
           - "network.incoming.packets"


### PR DESCRIPTION
See -- https://ask.openstack.org/en/question/58439/heat-error-you-are-not-authorized-to-complete-this-action/

` evaluation_interval must be set >= the the source interval in pipeline.yaml `

evaluation_interval is current configured as default of 60.


Example of situation this creates below -- See State = insufficient data
```
ceilometer alarm-list
+--------------------------------------+------------------------------------------------+-------------------+----------+---------+------------+-----------------------------------------+------------------+
| Alarm ID                             | Name                                           | State             | Severity | Enabled | Continuous | Alarm condition                         | Time constraints |
+--------------------------------------+------------------------------------------------+-------------------+----------+---------+------------+-----------------------------------------+------------------+
| 15ac1d5a-ff3e-42ce-b023-d6e81593d732 | levenson-heat-asg-01-InstanceDown-hmtlvpg5g5sr | insufficient data | low      | True    | True       | count(instance) < 2.0 during None x 60s | None             |
+--------------------------------------+------------------------------------------------+-------------------+----------+---------+------------+-----------------------------------------+------------------+
```

